### PR TITLE
Fix: #5 最近使ったファイルの直接オープン対応

### DIFF
--- a/builder/src/preload/index.ts
+++ b/builder/src/preload/index.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // テンプレートファイル関連
   openTemplateFile: () => ipcRenderer.invoke('open-template-file'),
   getRecentTemplates: () => ipcRenderer.invoke('get-recent-templates'),
+  openTemplateFromPath: (filePath: string) => ipcRenderer.invoke('open-template-from-path', filePath),
   
   // ファイル操作
   selectFile: (options?: {

--- a/builder/src/types/ipc.ts
+++ b/builder/src/types/ipc.ts
@@ -27,6 +27,7 @@ export interface LoggerAPI {
 export interface ElectronAPI {
   openTemplateFile: () => Promise<TemplateArchive | null>;
   getRecentTemplates: () => Promise<string[]>;
+  openTemplateFromPath: (filePath: string) => Promise<TemplateArchive>;
   selectFile: (options?: {
     filters?: { name: string; extensions: string[] }[];
     properties?: ('openFile' | 'multiSelections')[];


### PR DESCRIPTION
## 概要
- 最近使ったファイルから直接テンプレートを開くIPCを追加し、Renderer側で利用
- 最近使ったファイルの表示件数を5件に制限
- テンプレート読み込み後に最近リストを再取得し、エラーメッセージを改善

## テスト
- npm run build:renderer
