### PR TITLE
docs: update README to reflect current project status (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-# Criclify (旧: Doujin LP System)
+# Criclify
 
-同人作品向けランディングページ(LP)制作システム
+同人サークルのためのホームページビルダー
+
+**Criclify**（クリクリファイ）は、同人サークルが簡単にプロフェッショナルなランディングページ（LP）を作成できる、デスクトップアプリケーションです。テンプレートを選んで設定を変更するだけで、美しいWebサイトが完成します。
+
+## 特徴
+
+- 🎨 **テンプレート選択**: 6種類のプロ品質なテンプレートを標準搭載
+- ⚙️ **直感的な設定UI**: Schema-Driven UIで自動生成される設定フォーム
+- 👁️ **リアルタイムプレビュー**: 変更内容を即座に確認
+- 📦 **ワンクリックビルド**: 完成したサイトをZIPファイルとして出力
+- 🌍 **多言語対応**: 日本語/英語のUIをサポート
+- 🎯 **DLPT形式**: 独自のDoujin Landing Page Templateフォーマット
 
 ## プロジェクト構成
 
@@ -39,58 +50,76 @@ doujin-lp-system/
 │   ├── tsconfig.json
 │   └── vite.config.ts
 │
-├── templates/            # LPテンプレート集
-│   └── music-album-v1/  # 音楽アルバム用テンプレート v1
-│       ├── template.json
-│       ├── config.schema.json
-│       ├── config.default.json
-│       ├── index.html
-│       ├── style.css
-│       ├── script.js
-│       └── README.md
+├── templates/            # LPテンプレート集 (DLPT形式)
+│   ├── clearly-memory.dlpt  # クリアメモリー（透明感のあるデザイン）
+│   ├── gothic.dlpt          # ゴシック（ダークで重厚な雰囲気）
+│   ├── minimal.dlpt         # ミニマル（シンプルで洗練されたデザイン）
+│   ├── miyabi.dlpt          # 雅（和風の優雅なデザイン）
+│   ├── nocturne.dlpt        # ノクターン（夜をイメージした落ち着いた雰囲気）
+│   └── simple-serif.dlpt    # シンプルセリフ（読みやすいセリフ体）
+│
+├── docs/                 # ドキュメント
+│   ├── DLPT_FORMAT.md            # DLPT形式の仕様書
+│   ├── QUICKSTART.md             # クイックスタートガイド
+│   ├── README_TEMPLATE_SYSTEM.md # テンプレートシステムの詳細
+│   ├── MOBILE_POSITIONING_SPEC.md # モバイル対応仕様
+│   ├── LLM_PROMPT_COMPLETE.md    # LLMプロンプト完全版
+│   └── schema-template.json      # スキーマテンプレート
 │
 └── output/              # ビルド出力ディレクトリ
 ```
 
 ## 現在の進捗
 
-### ✅ 完了
-- [x] プロジェクト基本構造
-- [x] Music Album Template v1
-  - [x] template.json (マニフェスト)
-  - [x] config.schema.json (設定スキーマ)
-  - [x] config.default.json (デフォルト設定)
-  - [x] index.html (HTMLテンプレート)
-  - [x] style.css (スタイルシート)
-  - [x] script.js (JavaScript)
-  - [x] README.md (ドキュメント)
-- [x] LP Builder v1.0 基本機能
-  - [x] Electron + React + TypeScript セットアップ
-  - [x] テンプレート選択UI (TemplateSelector)
-  - [x] 既存テンプレート読み込み (TemplateOpener)
-  - [x] 設定編集UI (ConfigEditor)
-  - [x] リアルタイムプレビュー (PreviewPane)
-  - [x] 多言語対応 (日本語/英語)
-  - [x] ZIPビルド機能 (templateSaver)
-  - [x] Fluent UI 2 デザインシステム
+### ✅ 完了 (Phase 1 & 2)
 
-### 🚧 進行中
+**LP Builder v1.0 基本機能**:
+- [x] Electron + React + TypeScript セットアップ
+- [x] テンプレート選択UI (TemplateSelector)
+- [x] 既存テンプレート読み込み (TemplateOpener)
+- [x] 設定編集UI (ConfigEditor)
+- [x] リアルタイムプレビュー (PreviewPane)
+- [x] 多言語対応 (日本語/英語)
+- [x] ZIPビルド機能 (templateSaver)
+- [x] Fluent UI 2 デザインシステム
+
+**DLPTフォーマット** (#7):
+- [x] DLPT形式のサポート
+- [x] テンプレートの.dlpt形式への移行
+- [x] DLPTバリデーション機能
+- [x] エラーメッセージの日本語化
+
+**Hero画像フォーカル調整機能** (#9, #10):
+- [x] Hero画像のフォーカルポイント調整スライダー
+- [x] X/Y軸の独立制御
+- [x] リセットボタン
+- [x] 全テンプレートへの適用
+
+**テンプレート** (6種類):
+- [x] Clearly Memory (透明感のあるデザイン)
+- [x] Gothic (ダークで重厚な雰囲気)
+- [x] Minimal (シンプルで洗練されたデザイン)
+- [x] Miyabi (和風の優雅なデザイン)
+- [x] Nocturne (夜をイメージした落ち着いた雰囲気)
+- [x] Simple Serif (読みやすいセリフ体)
+
+### 🚧 進行中 (Phase 2)
 - [ ] ビルド機能の改善
   - [x] 基本的なZIPエクスポート
   - [ ] アセット最適化
   - [ ] エラーハンドリング強化
 
-### 📋 予定
-- [ ] 追加テンプレート
-  - [ ] Doujinshi Template (同人誌用)
-  - [ ] Game Template (ゲーム用)
-  - [ ] Event Template (イベント用)
+### 📋 予定 (Phase 3)
 - [ ] ビルダー機能拡張
   - [ ] テンプレートプラグインシステム
   - [ ] カスタムウィジェット追加
   - [ ] プロジェクト保存/読み込み
-- [ ] ドキュメント整備
-- [ ] サンプルサイト公開
+- [ ] 追加テンプレート
+  - [ ] Game Template (ゲーム用)
+  - [ ] Event Template (イベント用)
+- [ ] エコシステム
+  - [ ] テンプレートマーケットプレイス
+  - [ ] コミュニティギャラリー
 
 ## 使い方
 
@@ -114,17 +143,24 @@ npm run dev
 #### 1. テンプレートを選択
 
 1. LP Builderを起動
-2. 「新規プロジェクト」タブでテンプレートを選択 (例: Music Album v1)
-   - または「テンプレート読み込み」タブで既存のDLPTファイルを読み込み
+2. 「新規プロジェクト」タブでテンプレートを選択
+   - Clearly Memory: 透明感のあるデザイン
+   - Gothic: ダークで重厚な雰囲気
+   - Minimal: シンプルで洗練されたデザイン
+   - Miyabi: 和風の優雅なデザイン
+   - Nocturne: 夜をイメージした落ち着いた雰囲気
+   - Simple Serif: 読みやすいセリフ体
+3. または「テンプレート読み込み」タブで既存のDLPTファイルを読み込み
 
 #### 2. 設定を編集
 
 Schema-Driven UIにより、テンプレートの設定スキーマに基づいて自動生成されたフォームで編集:
 
-- 基本設定 (タイトル、説明文、URL等)
-- デザイン (色、背景画像等)
-- コンテンツ (トラックリスト、スタッフ等)
-- エフェクト (3D傾斜等)
+- **基本設定**: タイトル、説明文、URL等
+- **デザイン**: 色、背景画像、フォント等
+- **Hero画像**: フォーカルポイント調整 (X/Y軸スライダー)
+- **コンテンツ**: トラックリスト、作品情報、スタッフ等
+- **エフェクト**: 3D傾斜等
 
 #### 3. リアルタイムプレビュー
 
@@ -137,17 +173,20 @@ Schema-Driven UIにより、テンプレートの設定スキーマに基づい�
 3. 保存先を選択してZIPファイルを生成
 4. ZIPを解凍してWebサーバーにアップロード
 
+詳細は [docs/QUICKSTART.md](docs/QUICKSTART.md) をご覧ください。
+
 ## テンプレート開発
+
+### DLPT形式について
+
+Criclifyは独自の**DLPT (Doujin Landing Page Template)** 形式を使用しています。DLPTファイルは、テンプレートのすべての構成要素を1つのZIPアーカイブにまとめたものです。
+
+詳細は [docs/DLPT_FORMAT.md](docs/DLPT_FORMAT.md) をご覧ください。
 
 ### 新しいテンプレートを作成
 
-```bash
-cd templates/
-cp -r music-album-v1 your-template-name
-cd your-template-name
-```
+DLPTファイルに必要な構成要素:
 
-必要なファイル:
 - `template.json` - テンプレート情報
 - `config.schema.json` - 設定スキーマ (JSON Schema)
 - `config.default.json` - デフォルト設定
@@ -186,14 +225,17 @@ LP Builderは自動的にUIを生成します。
 - `select` - ドロップダウン
 - `radio` - ラジオボタン
 - `slider` - スライダー
+- `focal-slider` - フォーカルポイント調整スライダー (Hero画像用)
 - `array-editor` - 配列編集
+
+詳細は [docs/README_TEMPLATE_SYSTEM.md](docs/README_TEMPLATE_SYSTEM.md) をご覧ください。
 
 ## アーキテクチャ
 
 ### Schema-Driven UI Generation
 
 ```
-Template
+DLPT Template
   └── config.schema.json
         ↓
 LP Builder
@@ -217,12 +259,12 @@ CSS Optimization
   ↓
 Asset Copy
   ↓
-Static Site Output
+Static Site Output (ZIP)
 ```
 
 ## ビジネスモデル
 
-- **LP Builder**: 無料配布
+- **LP Builder**: 無料配布 (オープンソース)
 - **テンプレート**: 個別有料販売 (BOOTH等)
 - **価格帯**: ¥300-1,500 / テンプレート
 
@@ -230,7 +272,6 @@ Static Site Output
 
 - LP Builder: MIT License
 - Templates: 各テンプレートのライセンスに従う
-  - Music Album v1: MIT License
 
 ## 開発
 
@@ -290,7 +331,7 @@ npm run package
 
 ### Phase 1: MVP ✅ (完了)
 - [x] 基本構造設計
-- [x] Music Album Template v1
+- [x] 初期テンプレート開発
 - [x] LP Builder v1.0 基本機能
   - [x] テンプレート選択・読み込み
   - [x] Schema-Driven UI
@@ -298,31 +339,46 @@ npm run package
   - [x] ZIPビルド機能
   - [x] 多言語対応 (日本語/英語)
 
-### Phase 2: 機能拡張 🚧 (進行中)
+### Phase 2: 機能拡張 🚀 (進行中)
+- [x] DLPTフォーマット (#7)
+  - [x] DLPT形式のサポート
+  - [x] テンプレート移行
+  - [x] バリデーション機能
+- [x] Hero画像フォーカル調整 (#9, #10)
+  - [x] X/Y軸スライダー
+  - [x] リセット機能
+  - [x] 全テンプレート対応
+- [x] テンプレート拡充 (6種類)
 - [ ] ビルド機能改善
   - [x] 基本的なZIPエクスポート
   - [ ] アセット最適化
   - [ ] エラーハンドリング強化
-- [ ] 追加テンプレート (3種類)
-  - [ ] Doujinshi Template
-  - [ ] Game Template
-  - [ ] Event Template
+
+### Phase 3: エコシステム 📋 (予定)
 - [ ] ビルダー機能
   - [ ] プロジェクト保存/読み込み
   - [ ] テンプレートプラグインシステム
   - [ ] カスタムウィジェット
+- [ ] 追加テンプレート
+  - [ ] Game Template
+  - [ ] Event Template
+- [ ] コミュニティ
+  - [ ] テンプレートマーケットプレイス
+  - [ ] ギャラリー
+  - [ ] プラグインシステム拡張
 
-### Phase 3: エコシステム 📋 (予定)
-- [ ] テンプレートマーケットプレイス
-- [ ] コミュニティギャラリー
-- [ ] プラグインシステム拡張
-- [ ] クラウド連携機能
+## ドキュメント
+
+- [クイックスタート](docs/QUICKSTART.md)
+- [DLPT形式仕様](docs/DLPT_FORMAT.md)
+- [テンプレートシステム](docs/README_TEMPLATE_SYSTEM.md)
+- [モバイル対応仕様](docs/MOBILE_POSITIONING_SPEC.md)
+- [LLMプロンプト](docs/LLM_PROMPT_COMPLETE.md)
 
 ## サポート
 
-- **ドキュメント**: [準備中]
-- **GitHub Issues**: [準備中]
-- **Twitter**: [@your_account]
+- **GitHub Issues**: [bellsanct/doujin-LP-Builder/issues](https://github.com/bellsanct/doujin-LP-Builder/issues)
+- **ドキュメント**: [docs/](docs/)
 
 ## 作者
 
@@ -330,6 +386,6 @@ Doujin LP Project Team
 
 ---
 
-**Status**: 🚀 MVP Complete / Phase 2 In Progress
+**Status**: 🚀 Phase 2 In Progress
 **Version**: 1.0.0
 **Last Updated**: 2025-12-09


### PR DESCRIPTION
## 概要
このPRはAIによって自動生成されました。必ず人間がコードレビューを行ってください。

## 関連Issue
Closes #11

## 変更内容
- プロジェクト名を「Criclify」に更新
- 特徴セクションを追加
- テンプレート情報をDLPT形式に更新（6種類のテンプレート）
- DLPT形式サポートのドキュメント追加 (#7)
- Hero画像フォーカルポイント調整機能の追加 (#9, #10)
- docsディレクトリへの参照を追加
- プロジェクト構造とロードマップを更新
- ステータスをPhase 2進行中に更新

## 主な変更点

### プロジェクト名とサブタイトル
- タイトル: 「Criclify」
- サブタイトル: 「同人サークルのためのホームページビルダー」

### テンプレート情報
- 6つのDLPTファイルを反映:
  - Clearly Memory（透明感のあるデザイン）
  - Gothic（ダークで重厚な雰囲気）
  - Minimal（シンプルで洗練されたデザイン）
  - Miyabi（和風の優雅なデザイン）
  - Nocturne（夜をイメージした落ち着いた雰囲気）
  - Simple Serif（読みやすいセリフ体）

### 新機能の追加
- DLPTフォーマットサポート（#7で実装）
- Hero画像フォーカルポイント調整機能（#9, #10で実装）
- focal-sliderウィジェットの追加

### ドキュメント構造
- docsディレクトリへの参照を追加
- DLPT形式仕様書、クイックスタート等へのリンク

## 影響範囲
- ドキュメントのみの変更
- コードへの影響なし

## 確認事項
- [x] 現在のプロジェクト状況を正確に反映
- [x] 実装済み機能を記載
- [x] テンプレート情報の更新
- [x] ドキュメントへのリンク追加

---
🤖 このPRはClaude Codeによって自動生成されました。