### PR TITLE
Fix: #24 画像アセットをassetsへ保存

### DIFF
--- a/builder/src/preload/index.ts
+++ b/builder/src/preload/index.ts
@@ -40,6 +40,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   
   copyFile: (src: string, dest: string) => ipcRenderer.invoke('copy-file', src, dest),
   
+  cacheAssetBuffer: (payload: { filename?: string; data: number[]; mime?: string }) =>
+    ipcRenderer.invoke('cache-asset-buffer', payload),
+  
   // ビルド
   buildLP: (options: {
     template: any;

--- a/builder/src/types/ipc.ts
+++ b/builder/src/types/ipc.ts
@@ -42,6 +42,7 @@ export interface ElectronAPI {
   writeFile: (filePath: string, content: string) => Promise<boolean>;
   createDirectory: (dirPath: string) => Promise<boolean>;
   copyFile: (src: string, dest: string) => Promise<boolean>;
+  cacheAssetBuffer: (payload: { filename?: string; data: number[]; mime?: string }) => Promise<{ filePath: string; fileUrl: string; virtualPath: string }>;
   buildLP: (options: BuildRequest) => Promise<BuildResult>;
   log: LoggerAPI;
   onMenuEvent: (channel: string, callback: () => void) => () => void;


### PR DESCRIPTION
変更内容
- data URL抽出の正規表現を空白や改行を含むケースに対応
- base64を正規化し、デコード不可の場合はデータURLを残す安全策を追加
- ブラウザ側の静的エクスポートでも同じ処理を適用

## テスト
- node ./node_modules/typescript/bin/tsc -p tsconfig.main.json
- node ./node_modules/typescript/bin/tsc -p tsconfig.json （既存の型エラー多数で失敗、今回の変更とは無関係）